### PR TITLE
Add new monitor for CPU burst balances and remove CPU utilisation for RDS instances

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@
 /jest.config.js
 /.github
 
+*.test.js
 *.ts
 !*.d.ts
 *.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dddk",
-  "version": "0.0.7",
+  "version": "0.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dddk",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Datadog Development Kit",
   "main": "dist/src/index.js",
   "bin": {

--- a/src/shared/burstablerds.ts
+++ b/src/shared/burstablerds.ts
@@ -1,40 +1,168 @@
+import {
+  cpuStyle,
+  errorStyle,
+  memoryStyle,
+  trafficStyle,
+  upperBoundStyle,
+} from "./styles";
+
 import { Component } from "../index";
 
 export default function burstablerds(...dbname: string[]): Component {
   return container => {
+    container.addWidget("RDS CPU", {
+      type: "timeseries",
+      requests: dbname.map(dbname => ({
+        q: `avg:aws.rds.cpuutilization{name:${dbname}} by {host}`,
+        display_type: "line",
+        style: cpuStyle,
+      })),
+    });
+
+    container.addWidget("RDS Connections", {
+      type: "timeseries",
+      requests: dbname.map(dbname => ({
+        q: `max:aws.rds.database_connections{name:${dbname}} by {host}`,
+        display_type: "line",
+        style: trafficStyle,
+      })),
+    });
+
     dbname.forEach(dbname =>
-      container.addWarningMonitor(`EC2 CPU credit balance is low on ${dbname}`, {
+      container.addWarningMonitor(`RDS burst balance low on ${dbname}`, {
         type: "metric alert",
-        query: `max(last_1h):avg:aws.rds.cpucredit_balance{name:${dbname}} by {host} <= 100`,
+        query: `min(last_1h):max:aws.rds.burst_balance{name:${dbname}} by {host} <= 50`,
         message: `{{#is_warning}}
-            RDS CPUCreditBalance for {{host.name}} is below 200. Things will alert if it gets below 50%. Check what is happening on the RDS instance (why is the CPU credit balance depleting?).
+            RDS BurstBalance for {{host.name}}  is below 80%. Things will alert if it gets below 50%. Check what is happening on the RDS instance (why are the IOPS so high?).
         {{/is_warning}}
 
         {{#is_alert}}
-            RDS CPUCreditBalance for {{host.name}} is below 100! Throttling will occur if balance depletes.
+            RDS BurstBalance for {{host.name}} is below 50%! IOPS throughput will be throttled if this reaches 0%, possibly resulting in degraded RDS performance. Check what is happening on the RDS instance (why are the IOPS so high?).
         {{/is_alert}}
 
         {{#is_recovery}}
+            RDS BurstBalance for {{host.name}} is looking better now.
+        {{/is_recovery}}`,
+        options: {
+          new_host_delay: 300,
+          include_tags: false,
+          no_data_timeframe: 300,
+          notify_no_data: true,
+          thresholds: {
+            critical: 50,
+            warning: 80,
+          },
+        },
+      }),
+    );
+
+    dbname.forEach(dbname =>
+      container.addWarningMonitor(
+        `EC2 CPU credit balance is low on ${dbname}`,
+        {
+          type: "metric alert",
+          query: `max(last_1h):avg:aws.rds.cpucredit_balance{name:${dbname}} by {host} <= 100`,
+          message: `{{#is_warning}}
+            RDS CPUCreditBalance for {{host.name}} is below 200. Things will alert if it gets below 50%. Check what is happening on the RDS instance (why is the CPU credit balance depleting?).
+        {{/is_warning}}
+        {{#is_alert}}
+            RDS CPUCreditBalance for {{host.name}} is below 100! Throttling will occur if balance depletes.
+        {{/is_alert}}
+        {{#is_recovery}}
             RDS CPUCreditBalance for {{host.name}} is looking better now.
         {{/is_recovery}}`,
-        tags: [],
-        options: {
-          notify_audit: false,
-          locked: false,
-          timeout_h: 0,
-          silenced: {},
-          include_tags: false,
-          no_data_timeframe: null,
-          new_host_delay: 3600,
-          require_full_window: true,
-          notify_no_data: false,
-          renotify_interval: 0,
-          thresholds: {
-            critical: 100,
-            warning: 200
-          }
-        }
-    }),
+          tags: [],
+          options: {
+            notify_audit: false,
+            locked: false,
+            timeout_h: 0,
+            silenced: {},
+            include_tags: false,
+            no_data_timeframe: null,
+            new_host_delay: 3600,
+            require_full_window: true,
+            notify_no_data: false,
+            renotify_interval: 0,
+            thresholds: {
+              critical: 100,
+              warning: 200,
+            },
+          },
+        },
+      ),
     );
+
+    container.addWidget("Burst balance used", {
+      type: "timeseries",
+      requests: dbname.map(dbname => ({
+        q: `100 - max:aws.rds.burst_balance{name:${dbname}} by {host}`,
+        display_type: "line",
+        style: errorStyle,
+      })),
+    });
+
+    container.addWidget("RDS Memory use", {
+      type: "timeseries",
+      requests: dbname.flatMap(dbname => [
+        {
+          q: `max:aws.rds.swap_usage{name:${dbname}} by {host}`,
+          display_type: "line",
+          style: memoryStyle,
+        },
+        {
+          q: `max:aws.rds.freeable_memory{name:${dbname}} by {host}`,
+          display_type: "line",
+          style: memoryStyle,
+        },
+      ]),
+    });
+
+    container.addWidget("RDS io/s", {
+      type: "timeseries",
+      requests: dbname.flatMap(dbname => [
+        {
+          q: `autosmooth(avg:aws.rds.read_iops{name:${dbname}} by {host})`,
+          display_type: "line",
+          style: trafficStyle,
+        },
+        {
+          q: `autosmooth(avg:aws.rds.write_iops{name:${dbname}} by {host})`,
+          display_type: "line",
+          style: trafficStyle,
+        },
+      ]),
+    });
+
+    container.addWidget("RDS storage", {
+      type: "timeseries",
+      requests: dbname.flatMap(dbname => [
+        {
+          q: `avg:aws.rds.total_storage_space{name:${dbname}} by {host}`,
+          display_type: "line",
+          style: upperBoundStyle,
+        },
+        {
+          q: `avg:aws.rds.total_storage_space{name:${dbname}} by {host} - avg:aws.rds.free_storage_space{name:${dbname}} by {host}`,
+          display_type: "line",
+          style: memoryStyle,
+        },
+      ]),
+    });
+
+    container.addWidget("RDS latency", {
+      type: "timeseries",
+      requests: dbname.flatMap(dbname => [
+        {
+          q: `autosmooth(avg:aws.rds.read_latency{name:${dbname}} by {host})`,
+          display_type: "line",
+          style: trafficStyle,
+        },
+        {
+          q: `autosmooth(avg:aws.rds.write_latency{name:${dbname}} by {host})`,
+          display_type: "line",
+          style: trafficStyle,
+        },
+      ]),
+    });
   };
 }

--- a/src/shared/burstablerds.ts
+++ b/src/shared/burstablerds.ts
@@ -1,0 +1,40 @@
+import { Component } from "../index";
+
+export default function burstablerds(...dbname: string[]): Component {
+  return container => {
+    dbname.forEach(dbname =>
+      container.addWarningMonitor(`EC2 CPU credit balance is low on ${dbname}`, {
+        type: "metric alert",
+        query: `max(last_1h):avg:aws.rds.cpucredit_balance{name:${dbname}} by {host} <= 100`,
+        message: `{{#is_warning}}
+            RDS CPUCreditBalance for {{host.name}} is below 200. Things will alert if it gets below 50%. Check what is happening on the RDS instance (why is the CPU credit balance depleting?).
+        {{/is_warning}}
+
+        {{#is_alert}}
+            RDS CPUCreditBalance for {{host.name}} is below 100! Throttling will occur if balance depletes.
+        {{/is_alert}}
+
+        {{#is_recovery}}
+            RDS CPUCreditBalance for {{host.name}} is looking better now.
+        {{/is_recovery}}`,
+        tags: [],
+        options: {
+          notify_audit: false,
+          locked: false,
+          timeout_h: 0,
+          silenced: {},
+          include_tags: false,
+          no_data_timeframe: null,
+          new_host_delay: 3600,
+          require_full_window: true,
+          notify_no_data: false,
+          renotify_interval: 0,
+          thresholds: {
+            critical: 100,
+            warning: 200
+          }
+        }
+    }),
+    );
+  };
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -4,6 +4,7 @@ export {default as fargate}  from "./fargate";
 export {default as healthcheck}  from "./healthcheck";
 export {default as mute}  from "./mute";
 export {default as rds}  from "./rds";
+export {default as burstablerds} from "./burstablerds";
 export * from "./styles";
 
 

--- a/src/shared/rds.ts
+++ b/src/shared/rds.ts
@@ -56,6 +56,22 @@ export default function rds(...dbname: string[]): Component {
       }),
     );
 
+    dbname.forEach(dbname =>
+      container.addWarningMonitor(`RDS CPU use is high on ${dbname}`, {
+        type: "metric alert",
+        query: `avg(last_5m):avg:aws.rds.cpuutilization{name:${dbname}} by {host} > 80`,
+        message: `CPU use is high on database instance ${dbname.split(":")[1]}`,
+        options: {
+          new_host_delay: 300,
+          include_tags: false,
+          thresholds: {
+            critical: 80,
+            warning: 60,
+          },
+        },
+      }),
+    );
+
     container.addWidget("Burst balance used", {
       type: "timeseries",
       requests: dbname.map(dbname => ({

--- a/src/shared/rds.ts
+++ b/src/shared/rds.ts
@@ -55,21 +55,6 @@ export default function rds(...dbname: string[]): Component {
         },
       }),
     );
-    dbname.forEach(dbname =>
-      container.addWarningMonitor(`RDS CPU use is high on ${dbname}`, {
-        type: "metric alert",
-        query: `avg(last_5m):avg:aws.rds.cpuutilization{name:${dbname}} by {host} > 80`,
-        message: `CPU use is high on database instance ${dbname.split(":")[1]}`,
-        options: {
-          new_host_delay: 300,
-          include_tags: false,
-          thresholds: {
-            critical: 80,
-            warning: 60,
-          },
-        },
-      }),
-    );
 
     container.addWidget("Burst balance used", {
       type: "timeseries",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2017"],
-    "types": ["node"],
+    "types": ["node", "@types/jest"],
     "module": "commonjs",
     "esModuleInterop": true,
     "pretty": true,
@@ -17,7 +17,6 @@
   ],
   "exclude": [
     "node_modules",
-    "dist",
-    "**/*.test.ts"
+    "dist"
   ]
 }


### PR DESCRIPTION
Since all the RDS instances have IOPS and CPU burst balance there is no need to monitor for CPU utilisation. We do need to monitor for both IOPS and CPU burst balances. This PR adds the CPU credit balance monitor which will be used by monitors repo in all the instances where burst CPU credits need to be monitored.