### PR TITLE
Add unified service tagging aware fargate metrics and monitors

### DIFF
--- a/src/shared/fargateService.ts
+++ b/src/shared/fargateService.ts
@@ -3,7 +3,7 @@ import { Component } from "../index";
 
 // Utilises unified service tagging to filter metrics and monitors
 // https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=ecs
-export default function fargateService(service: string): Component {
+export default function fargateService(service: string, env: string = 'production'): Component {
   return container => {
     container.addWidget("Container memory use (%)", {
       type: "timeseries",
@@ -19,12 +19,12 @@ export default function fargateService(service: string): Component {
       ],
       requests: [
         {
-          q: `(avg:ecs.fargate.mem.rss{service:${service}} by {container_id}/avg:ecs.fargate.mem.limit{service:${service}} by {container_id})*100`,
+          q: `(avg:ecs.fargate.mem.rss{service:${service},env:${env}} by {container_id}/avg:ecs.fargate.mem.limit{service:${service},env:${env}} by {container_id})*100`,
           display_type: "line",
           style: memoryStyle,
         },
         {
-          q: `(week_before(avg:ecs.fargate.mem.rss{service:${service}})/week_before(avg:ecs.fargate.mem.limit{service:${service}}))*100`,
+          q: `(week_before(avg:ecs.fargate.mem.rss{service:${service},env:${env}})/week_before(avg:ecs.fargate.mem.limit{service:${service},env:${env}}))*100`,
           display_type: "line",
           style: weekBeforeStyle,
         },
@@ -35,7 +35,7 @@ export default function fargateService(service: string): Component {
       `Fargate container memory use is high on ${service}`,
       {
         type: "query alert",
-        query: `avg(last_15m):(avg:ecs.fargate.mem.rss{service:${service}} by {container_id}/avg:ecs.fargate.mem.limit{service:${service}} by {container_id})*100 > 90`,
+        query: `avg(last_15m):(avg:ecs.fargate.mem.rss{service:${service},env:${env}} by {container_id}/avg:ecs.fargate.mem.limit{service:${service},env:${env}} by {container_id})*100 > 90`,
         message: `
           {{#is_alert}}
             Memory use for container {{container_id}} is too high, if it hits 100% ECS will automatically restart the
@@ -59,12 +59,12 @@ export default function fargateService(service: string): Component {
       type: "timeseries",
       requests: [
         {
-          q: `count_not_null(avg:ecs.fargate.cpu.user{service:${service}} by {container_id})`,
+          q: `count_not_null(avg:ecs.fargate.cpu.user{service:${service},env:${env}} by {container_id})`,
           display_type: "line",
           style: memoryStyle,
         },
         {
-          q: `week_before(count_not_null(avg:ecs.fargate.cpu.user{service:${service}} by {container_id}))`,
+          q: `week_before(count_not_null(avg:ecs.fargate.cpu.user{service:${service},env:${env}} by {container_id}))`,
           display_type: "line",
           style: weekBeforeStyle,
         },
@@ -75,7 +75,7 @@ export default function fargateService(service: string): Component {
       `Fargate container CPU use is high on ${service}`,
       {
         type: "query alert",
-        query: `avg(last_15m):avg:ecs.fargate.cpu.percent{service:${service}} by {container_id} > 80`,
+        query: `avg(last_15m):avg:ecs.fargate.cpu.percent{service:${service},env:${env}} by {container_id} > 80`,
         message: `
           {{#is_alert}}
             CPU use for container {{container_id}} is too high, this results in degraded performance and some
@@ -106,12 +106,12 @@ export default function fargateService(service: string): Component {
       ],
       requests: [
         {
-          q: `autosmooth(avg:ecs.fargate.cpu.percent{service:${service}} by {container_id})`,
+          q: `autosmooth(avg:ecs.fargate.cpu.percent{service:${service},env:${env}} by {container_id})`,
           display_type: "line",
           style: cpuStyle,
         },
         {
-          q: `autosmooth(week_before(avg:ecs.fargate.cpu.percent{service:${service}}))`,
+          q: `autosmooth(week_before(avg:ecs.fargate.cpu.percent{service:${service},env:${env}}))`,
           display_type: "line",
           style: weekBeforeStyle,
         },

--- a/src/shared/fargateService.ts
+++ b/src/shared/fargateService.ts
@@ -1,0 +1,121 @@
+import { cpuStyle, memoryStyle, weekBeforeStyle } from "./styles";
+import { Component } from "../index";
+
+// Utilises unified service tagging to filter metrics and monitors
+// https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=ecs
+export default function fargateService(service: string): Component {
+  return container => {
+    container.addWidget("Container memory use (%)", {
+      type: "timeseries",
+      markers: [
+        {
+          value: "y = 70",
+          display_type: "warning dashed",
+        },
+        {
+          value: "y = 90",
+          display_type: "error dashed",
+        },
+      ],
+      requests: [
+        {
+          q: `(avg:ecs.fargate.mem.rss{service:${service}} by {container_id}/avg:ecs.fargate.mem.limit{service:${service}} by {container_id})*100`,
+          display_type: "line",
+          style: memoryStyle,
+        },
+        {
+          q: `(week_before(avg:ecs.fargate.mem.rss{service:${service}})/week_before(avg:ecs.fargate.mem.limit{service:${service}}))*100`,
+          display_type: "line",
+          style: weekBeforeStyle,
+        },
+      ],
+    });
+
+    container.addWarningMonitor(
+      `Fargate container memory use is high on ${service}`,
+      {
+        type: "query alert",
+        query: `avg(last_15m):(avg:ecs.fargate.mem.rss{service:${service}} by {container_id}/avg:ecs.fargate.mem.limit{service:${service}} by {container_id})*100 > 90`,
+        message: `
+          {{#is_alert}}
+            Memory use for container {{container_id}} is too high, if it hits 100% ECS will automatically restart the
+            container. This usually causes a few dropped requests before the ELB marks this instance as unhealthy.
+          {{/is_alert}}
+
+          {{#is_recovery}}
+            Memory use back within threshold.
+          {{/is_recovery}}
+      `,
+        options: {
+          include_tags: false,
+          thresholds: {
+            critical: 90,
+          },
+        },
+      },
+    );
+
+    container.addWidget("Container count", {
+      type: "timeseries",
+      requests: [
+        {
+          q: `count_not_null(avg:ecs.fargate.cpu.user{service:${service}} by {container_id})`,
+          display_type: "line",
+          style: memoryStyle,
+        },
+        {
+          q: `week_before(count_not_null(avg:ecs.fargate.cpu.user{service:${service}} by {container_id}))`,
+          display_type: "line",
+          style: weekBeforeStyle,
+        },
+      ],
+    });
+
+    container.addWarningMonitor(
+      `Fargate container CPU use is high on ${service}`,
+      {
+        type: "query alert",
+        query: `avg(last_15m):avg:ecs.fargate.cpu.percent{service:${service}} by {container_id} > 80`,
+        message: `
+          {{#is_alert}}
+            CPU use for container {{container_id}} is too high, this results in degraded performance and some
+            requests may start timing out.
+          {{/is_alert}}
+
+          {{#is_recovery}}
+            CPU use is back within threshold
+          {{/is_recovery}}
+                `,
+        options: {
+          include_tags: false,
+          thresholds: {
+            critical: 80,
+            critical_recovery: 70,
+          },
+        },
+      },
+    );
+
+    container.addWidget("CPU utilization (fargate)", {
+      type: "timeseries",
+      markers: [
+        {
+          value: "y < 100",
+          display_type: "info solid",
+        },
+      ],
+      requests: [
+        {
+          q: `autosmooth(avg:ecs.fargate.cpu.percent{service:${service}} by {container_id})`,
+          display_type: "line",
+          style: cpuStyle,
+        },
+        {
+          q: `autosmooth(week_before(avg:ecs.fargate.cpu.percent{service:${service}}))`,
+          display_type: "line",
+          style: weekBeforeStyle,
+        },
+      ],
+    });
+  };
+}


### PR DESCRIPTION
[Unified service tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=ecs) is a way of tying together
together telemetry through the use of reserved tags. These then are exposed with the `service` tag, which can be
filtered on within metrics and monitors.

The nice thing about this is that it will exclude other containers that are running within
a given task definition, which we can use to target only the specific containers we want
for `fargate` services.

This adds a new `fargateService` component that can be used to filter and monitor on these
new tags. The existing `fargate` component can still be used until your service supports
unified service tagging.