### PR TITLE
Expose `fargateService` component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dddk",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dddk",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Datadog Development Kit",
   "main": "dist/src/index.js",
   "bin": {

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,10 +1,9 @@
-export {default as alb}  from "./alb";
-export {default as elb}  from "./elb";
-export {default as fargate}  from "./fargate";
-export {default as healthcheck}  from "./healthcheck";
-export {default as mute}  from "./mute";
-export {default as rds}  from "./rds";
-export {default as burstablerds} from "./burstablerds";
+export { default as alb } from "./alb";
+export { default as elb } from "./elb";
+export { default as fargate } from "./fargate";
+export { default as healthcheck } from "./healthcheck";
+export { default as mute } from "./mute";
+export { default as rds } from "./rds";
+export { default as burstablerds } from "./burstablerds";
+export { default as fargateService } from "./fargateService";
 export * from "./styles";
-
-


### PR DESCRIPTION
Exposes the `fargateService` component in the `shared` module. 
Bumps version to `0.0.15`. 