### PR TITLE
Update host counts to reflect availability zones, add 500 errors to alb traffic stats

### DIFF
--- a/src/shared/alb.ts
+++ b/src/shared/alb.ts
@@ -81,12 +81,12 @@ export default function alb(name: string, titlePrefix: string = ""): Component {
       type: "timeseries",
       requests: [
         {
-          q: `sum:aws.elb.httpcode_target_2xx{name:${name}}.as_rate(), sum:aws.elb.httpcode_target_3xx{name:${name}}.as_rate(), sum:aws.elb.httpcode_target_5xx{name:${name}}.as_rate()`,
+          q: `sum:aws.elb.httpcode_target_2xx{name:${name}}.as_rate(), sum:aws.elb.httpcode_target_3xx{name:${name}}.as_rate(), sum:aws.elb.httpcode_target_4xx{name:${name}}.as_rate(), sum:aws.elb.httpcode_target_5xx{name:${name}}.as_rate()`,
           display_type: "area",
           style: trafficStyle,
         },
         {
-          q: `week_before(sum:aws.elb.httpcode_target_2xx{name:${name}}.as_rate()) + week_before(sum:aws.elb.httpcode_target_3xx{name:${name}}.as_rate()) + week_before(sum:aws.elb.httpcode_target_5xx{name:${name}}.as_rate())`,
+          q: `week_before(sum:aws.elb.httpcode_target_2xx{name:${name}}.as_rate()) + week_before(sum:aws.elb.httpcode_target_3xx{name:${name}}.as_rate()) + week_before(sum:aws.elb.httpcode_target_4xx{name:${name}}.as_rate()) + week_before(sum:aws.elb.httpcode_target_5xx{name:${name}}.as_rate())`,
           display_type: "line",
           style: weekBeforeStyle,
         },

--- a/src/shared/alb.ts
+++ b/src/shared/alb.ts
@@ -32,7 +32,7 @@ export default function alb(name: string, titlePrefix: string = ""): Component {
       type: "timeseries",
       requests: [
         {
-          q: `min:aws.elb.healthy_host_count{name:${name}}.rollup(min), max:aws.elb.un_healthy_host_count{name:${name}}.rollup(max)`,
+          q: `sum:aws.elb.healthy_host_count{name:${name}}.rollup(sum), sum:aws.elb.un_healthy_host_count{name:${name}}.rollup(sum)`,
           display_type: "area",
           style: trafficStyle,
         },
@@ -81,12 +81,12 @@ export default function alb(name: string, titlePrefix: string = ""): Component {
       type: "timeseries",
       requests: [
         {
-          q: `sum:aws.elb.httpcode_target_2xx{name:${name}}.as_rate(), sum:aws.elb.httpcode_target_3xx{name:${name}}.as_rate()`,
+          q: `sum:aws.elb.httpcode_target_2xx{name:${name}}.as_rate(), sum:aws.elb.httpcode_target_3xx{name:${name}}.as_rate(), sum:aws.elb.httpcode_target_5xx{name:${name}}.as_rate()`,
           display_type: "area",
           style: trafficStyle,
         },
         {
-          q: `week_before(sum:aws.elb.httpcode_target_2xx{name:${name}}.as_rate()) + week_before(sum:aws.elb.httpcode_target_3xx{name:${name}}.as_rate())`,
+          q: `week_before(sum:aws.elb.httpcode_target_2xx{name:${name}}.as_rate()) + week_before(sum:aws.elb.httpcode_target_3xx{name:${name}}.as_rate()) + week_before(sum:aws.elb.httpcode_target_5xx{name:${name}}.as_rate())`,
           display_type: "line",
           style: weekBeforeStyle,
         },

--- a/src/shared/alb.ts
+++ b/src/shared/alb.ts
@@ -32,7 +32,7 @@ export default function alb(name: string, titlePrefix: string = ""): Component {
       type: "timeseries",
       requests: [
         {
-          q: `sum:aws.elb.healthy_host_count{name:${name}}.rollup(sum), sum:aws.elb.un_healthy_host_count{name:${name}}.rollup(sum)`,
+          q: `sum:aws.elb.healthy_host_count{name:${name}}.rollup(min), sum:aws.elb.un_healthy_host_count{name:${name}}.rollup(max)`,
           display_type: "area",
           style: trafficStyle,
         },


### PR DESCRIPTION
This PR will sum the healthy and unhealthy host counts instead of using the max and min respectively. This will allow us to see the total number of healthy hosts across all availability zones instead of just showing us the max number.

The PR also adds 500 errors to the alb traffic stats, giving a better representation of the total traffic hitting the alb.