### PR TITLE
Fix deletion order for unseen resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dddk",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dddk",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Datadog Development Kit",
   "main": "dist/src/index.js",
   "bin": {

--- a/src/syncer.ts
+++ b/src/syncer.ts
@@ -140,10 +140,10 @@ export class Syncer {
   }
 
   async deleteUnseen() {
-    await this.state.synthetics.deleteUnseen();
-    await this.state.slos.deleteUnseen();
-    await this.state.monitors.deleteUnseen();
     await this.state.dashboards.deleteUnseen();
+    await this.state.slos.deleteUnseen();
+    await this.state.synthetics.deleteUnseen();
+    await this.state.monitors.deleteUnseen();
   }
 
   get lock(): LockFile {


### PR DESCRIPTION
In the DataDog API there is a dependency relation between dashboards and SLOs (and probably other resources), so if we try to delete an SLO before the dashboard it's referenced in we get an error like the following:
```
error calling datadog api: {"errors":"slo 9c7418666a6b519798a58ffe901edbab is referenced in dashboard_id: qsa-6ia-chy","data":null}
```
This change flips around the order to delete dashboards first.