### PR TITLE
Allow for configurable tags for Fargate widgets and monitors

### DIFF
--- a/src/shared/fargate.ts
+++ b/src/shared/fargate.ts
@@ -2,7 +2,7 @@ import { cpuStyle, memoryStyle, weekBeforeStyle } from "./styles";
 import { Component } from "../index";
 
 // fargate ecs stacks, not plain ECS
-export default function fargate(ecs_task_family: string): Component {
+export default function fargate(tag_key: string, tag_value: string): Component {
   return container => {
     container.addWidget("Container memory use (%)", {
       type: "timeseries",
@@ -18,12 +18,12 @@ export default function fargate(ecs_task_family: string): Component {
       ],
       requests: [
         {
-          q: `(avg:ecs.fargate.mem.rss{ecs_task_family:${ecs_task_family}} by {container_id}/avg:ecs.fargate.mem.limit{ecs_task_family:${ecs_task_family}} by {container_id})*100`,
+          q: `(avg:ecs.fargate.mem.rss{${tag_key}:${tag_value}} by {container_id}/avg:ecs.fargate.mem.limit{${tag_key}:${tag_value}} by {container_id})*100`,
           display_type: "line",
           style: memoryStyle,
         },
         {
-          q: `(week_before(avg:ecs.fargate.mem.rss{ecs_task_family:${ecs_task_family}})/week_before(avg:ecs.fargate.mem.limit{ecs_task_family:${ecs_task_family}}))*100`,
+          q: `(week_before(avg:ecs.fargate.mem.rss{${tag_key}:${tag_value}})/week_before(avg:ecs.fargate.mem.limit{${tag_key}:${tag_value}}))*100`,
           display_type: "line",
           style: weekBeforeStyle,
         },
@@ -31,10 +31,10 @@ export default function fargate(ecs_task_family: string): Component {
     });
 
     container.addWarningMonitor(
-      `Fargate container memory use is high on ${ecs_task_family}`,
+      `Fargate container memory use is high on ${tag_value}`,
       {
         type: "query alert",
-        query: `avg(last_15m):(avg:ecs.fargate.mem.rss{ecs_task_family:${ecs_task_family}} by {container_id}/avg:ecs.fargate.mem.limit{ecs_task_family:${ecs_task_family}} by {container_id})*100 > 90`,
+        query: `avg(last_15m):(avg:ecs.fargate.mem.rss{${tag_key}:${tag_value}} by {container_id}/avg:ecs.fargate.mem.limit{${tag_key}:${tag_value}} by {container_id})*100 > 90`,
         message: `
           {{#is_alert}}
             Memory use for container {{container_id}} is too high, if it hits 100% ECS will automatically restart the
@@ -58,12 +58,12 @@ export default function fargate(ecs_task_family: string): Component {
       type: "timeseries",
       requests: [
         {
-          q: `count_not_null(avg:ecs.fargate.cpu.user{ecs_task_family:${ecs_task_family}} by {container_id})`,
+          q: `count_not_null(avg:ecs.fargate.cpu.user{${tag_key}:${tag_value}} by {container_id})`,
           display_type: "line",
           style: memoryStyle,
         },
         {
-          q: `week_before(count_not_null(avg:ecs.fargate.cpu.user{ecs_task_family:${ecs_task_family}} by {container_id}))`,
+          q: `week_before(count_not_null(avg:ecs.fargate.cpu.user{${tag_key}:${tag_value}} by {container_id}))`,
           display_type: "line",
           style: weekBeforeStyle,
         },
@@ -71,10 +71,10 @@ export default function fargate(ecs_task_family: string): Component {
     });
 
     container.addWarningMonitor(
-      `Fargate container CPU use is high on ${ecs_task_family}`,
+      `Fargate container CPU use is high on ${tag_value}`,
       {
         type: "query alert",
-        query: `avg(last_15m):avg:ecs.fargate.cpu.percent{ecs_task_family:${ecs_task_family}} by {container_id} > 80`,
+        query: `avg(last_15m):avg:ecs.fargate.cpu.percent{${tag_key}:${tag_value}} by {container_id} > 80`,
         message: `
           {{#is_alert}}
             CPU use for container {{container_id}} is too high, this results in degraded performance and some
@@ -105,12 +105,12 @@ export default function fargate(ecs_task_family: string): Component {
       ],
       requests: [
         {
-          q: `autosmooth(avg:ecs.fargate.cpu.percent{ecs_task_family:${ecs_task_family}} by {container_id})`,
+          q: `autosmooth(avg:ecs.fargate.cpu.percent{${tag_key}:${tag_value}} by {container_id})`,
           display_type: "line",
           style: cpuStyle,
         },
         {
-          q: `autosmooth(week_before(avg:ecs.fargate.cpu.percent{ecs_task_family:${ecs_task_family}}))`,
+          q: `autosmooth(week_before(avg:ecs.fargate.cpu.percent{${tag_key}:${tag_value}}))`,
           display_type: "line",
           style: weekBeforeStyle,
         },


### PR DESCRIPTION
Using `ecs_task_family` for Fargate tasks that contain both a datadog container and an app container can change the CPU and Memory monitors providing incorrect app metrics.

This PR updates the `shared.fargate()` component to force clients to specify the tag key and value used for monitoring for more flexibility. 