### PR TITLE
Update add outage monitor to not alert for warnings only

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1,8 +1,8 @@
 import { App } from "./app";
 
-let app;
-
 describe("outage monitor", () => {
+  let app;
+
   beforeEach(() => {
     app = new App({
       name: "testService",

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1,0 +1,54 @@
+import { App } from "./app";
+
+let app;
+
+describe("outage monitor", () => {
+  beforeEach(() => {
+    app = new App({
+      name: "testService",
+      team: {
+        warningContact: "@testWarningContact",
+        alertContact: "@testAlertContact",
+      },
+      components: [],
+    });
+  });
+
+  test("without warning", () => {
+    app.addOutageMonitor("testOutageMonitor", {
+      message:
+        "{{#is_alert}}alert message{{/is_alert}}" +
+        "{{#is_recovery}}recovery message{{/is_recovery}}" +
+        "{{#is_something}}another message{{/is_something}}",
+    });
+
+    expect(app.outageMonitors[0]).toEqual({
+      name: "testOutageMonitor",
+      message:
+        "{{#is_alert}}alert message @testAlertContact{{/is_alert}}" +
+        "{{#is_recovery}}recovery message @testAlertContact{{/is_recovery}}" +
+        "{{#is_something}}another message @testAlertContact{{/is_something}}" +
+        " @testWarningContact",
+      tags: ["service:testservice"],
+    });
+  });
+
+  test("with warning", () => {
+    app.addOutageMonitor("testOutageMonitor", {
+      message:
+        "{{#is_alert}}alert message{{/is_alert}}" +
+        "{{#is_warning}}warning message{{/is_warning}}" +
+        "{{#is_recovery}}recovery message{{/is_recovery}}",
+    });
+
+    expect(app.outageMonitors[0]).toEqual({
+      name: "testOutageMonitor",
+      message:
+        "{{#is_alert}}alert message @testAlertContact{{/is_alert}}" +
+        "{{#is_warning}}warning message{{/is_warning}}" +
+        "{{#is_recovery}}recovery message @testAlertContact{{/is_recovery}}" +
+        " @testWarningContact",
+      tags: ["service:testservice"],
+    });
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -48,8 +48,8 @@ export class App implements Container {
 
   addOutageMonitor(name: string, { tags, message, ...monitor }: Monitor) {
     const messageWithAlertContactInserted = message.replace(
-      /\{\{\/(?!is_warning)/g,
-      ` ${this.team.alertContact}{{/`,
+      /\{\{\/is_(?!warning)/g,
+      ` ${this.team.alertContact}{{/is_`,
     );
 
     this.outageMonitors.push({

--- a/src/app.ts
+++ b/src/app.ts
@@ -46,14 +46,20 @@ export class App implements Container {
     });
   }
 
+  injectAlertContactToNonWarningNotifications(message) {
+    const { alertContact } = this.team;
+
+    return stripIndent(
+      message.replace(/\{\{\/(?!is_warning)/g, ` ${alertContact}{{/`),
+    );
+  }
+
   addOutageMonitor(name: string, { tags, message, ...monitor }: Monitor) {
     this.outageMonitors.push({
       ...monitor,
       name: name,
       message:
-        stripIndent(message) +
-        " " +
-        this.team.alertContact +
+        this.injectAlertContactToNonWarningNotifications(message) +
         " " +
         this.team.warningContact,
       tags: tags ? tags : ["service:" + this.name.toLowerCase()],

--- a/src/app.ts
+++ b/src/app.ts
@@ -46,20 +46,17 @@ export class App implements Container {
     });
   }
 
-  injectAlertContactToNonWarningNotifications(message) {
-    const { alertContact } = this.team;
-
-    return stripIndent(
-      message.replace(/\{\{\/(?!is_warning)/g, ` ${alertContact}{{/`),
-    );
-  }
-
   addOutageMonitor(name: string, { tags, message, ...monitor }: Monitor) {
+    const messageWithAlertContactInserted = message.replace(
+      /\{\{\/(?!is_warning)/g,
+      ` ${this.team.alertContact}{{/`,
+    );
+
     this.outageMonitors.push({
       ...monitor,
       name: name,
       message:
-        this.injectAlertContactToNonWarningNotifications(message) +
+        stripIndent(messageWithAlertContactInserted) +
         " " +
         this.team.warningContact,
       tags: tags ? tags : ["service:" + this.name.toLowerCase()],


### PR DESCRIPTION
## What
Update `addOutageMonitor` to only insert `alertContact` details for non warning messages.

## Why
When using `addOutageMonitor` the warning threshold was alerting PagerDuty (alertContact) when it should have only been notifying slack (warningContact). 

This is because the alert contact was being added to the entire monitor message rather than just to the non warning notification sections. This resulted in an on call person being woken up many times over the least few days when the warning was being thrown, we are looking into the issue that it's warning about separately but think fixing the alert format is also a good idea. 