### PR TITLE
Fix no_data_timeframe value to be in a ideal range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dddk",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dddk",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Datadog Development Kit",
   "main": "dist/src/index.js",
   "bin": {

--- a/src/shared/alb.ts
+++ b/src/shared/alb.ts
@@ -48,10 +48,10 @@ export default function alb(name: string, titlePrefix: string = ""): Component {
         {{/is_alert}}`,
       options: {
         include_tags: false,
-        no_data_timeframe: 900,
+        no_data_timeframe: 15, // in minutes
         notify_no_data: true,
-        new_host_delay: 300,
-        evaluation_delay: 900,
+        new_host_delay: 300, // in seconds
+        evaluation_delay: 900, // in seconds
         thresholds: {
           critical: 1,
         },
@@ -67,10 +67,10 @@ export default function alb(name: string, titlePrefix: string = ""): Component {
         {{/is_alert}}`,
       options: {
         include_tags: false,
-        no_data_timeframe: 900,
+        no_data_timeframe: 15, // in minutes
         notify_no_data: true,
-        new_host_delay: 300,
-        evaluation_delay: 900,
+        new_host_delay: 300, // in seconds
+        evaluation_delay: 900, // in seconds
         thresholds: {
           critical: 0.05,
         },

--- a/src/shared/elb.ts
+++ b/src/shared/elb.ts
@@ -34,10 +34,10 @@ export default function elb(name: string): Component {
         {{/is_alert}}`,
       options: {
         include_tags: false,
-        no_data_timeframe: 900,
+        no_data_timeframe: 15, // in minutes
         notify_no_data: true,
-        new_host_delay: 300,
-        evaluation_delay: 900,
+        new_host_delay: 300, // in seconds
+        evaluation_delay: 900, // in seconds
         thresholds: {
           critical: 1,
         },
@@ -53,10 +53,10 @@ export default function elb(name: string): Component {
         {{/is_alert}}`,
       options: {
         include_tags: false,
-        no_data_timeframe: 900,
+        no_data_timeframe: 15, // in minutes
         notify_no_data: true,
-        new_host_delay: 300,
-        evaluation_delay: 900,
+        new_host_delay: 300, // in seconds
+        evaluation_delay: 900, // in seconds
         thresholds: {
           critical: 0.05,
         },


### PR DESCRIPTION
**Context:**
The current value of `no_data_timeframe` is 900 which is 15 hours. Hence the monitors wouldn't trigger the necessary alert when required. Fixing this to 15 minutes.

**Changes:**
- Updated the no_data_timeframe value to 15 minutes.
- Added comments for clarity to represent the units in which the values are used.

**Refs**
- https://docs.datadoghq.com/monitors/guide/monitor_api_options/#common-options
- https://docs.datadoghq.com/monitors/guide/monitor_api_options/#metric-alert-options
