### PR TITLE
Extend Monitor Type

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -24,6 +24,17 @@ export interface MetricMonitor {
   options: MonitorOptions;
 }
 
+export interface CompositeMonitor {
+  id?: number;
+  type: "composite";
+  query: string;
+  name?: string;
+  message: string;
+  tags?: string[];
+  modified?: Date;
+  options: MonitorOptions;
+}
+
 export interface MonitorOptions {
   notify_audit?: boolean;
   locked?: boolean;
@@ -49,7 +60,7 @@ export interface MonitorOptions {
   };
 }
 
-export type Monitor = QueryMonitor | MetricMonitor;
+export type Monitor = QueryMonitor | MetricMonitor | CompositeMonitor;
 
 export interface Threshold {
   timeframe: string;


### PR DESCRIPTION
## Extend Monitor Type
This PR adds a CompositeMonitor type to the existing Monitor type, enabling Datadog composite monitor support. 

For more details, refer to the [Datadog documentation](https://docs.datadoghq.com/api/latest/monitors/?code-lang=typescript#composite-query).